### PR TITLE
Fix CI trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,11 @@ name: Docker Image CI
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 5.7/**
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
     paths:
       - 5.7/**
   workflow_dispatch:


### PR DESCRIPTION
Fix CI trigger. The default branch of this repository is `main`.